### PR TITLE
Instrument dropdown dev

### DIFF
--- a/assets/scripts/bot_views.py
+++ b/assets/scripts/bot_views.py
@@ -1,0 +1,79 @@
+import sys
+sys.path.append("..")
+import discord
+import typing
+import pretty_midi
+
+class InstrumentSelectDropdownView(discord.ui.View):
+    def __init__(self, author: typing.Union[discord.Member, discord.User]):
+        super().__init__()
+        self.value = None
+        self.author = author
+    
+    @discord.ui.select(
+        placeholder="Select an instrument to render generated midi.",
+        options=[
+            discord.SelectOption(label=pretty_midi.program_to_instrument_name(0), value=0, emoji="🎹",description="MIDI Program: 0"),
+            discord.SelectOption(label=pretty_midi.program_to_instrument_name(4), value=4, emoji="🎹",description="MIDI Program: 4"),
+            discord.SelectOption(label=pretty_midi.program_to_instrument_name(24), value=24, emoji="🎸",description="MIDI Program: 24")
+        ]
+    )
+    async def select_callback(self, interaction, select):
+        await interaction.response.send_message(content=f"{select.values[0]} set!",ephemeral=False)
+        self.value = select.values[0]
+        self.stop()
+
+# Define a simple View that gives us a confirmation menu
+class Rating(discord.ui.View):
+    def __init__(self, author: typing.Union[discord.Member, discord.User]):
+        super().__init__()
+        self.value = None
+        self.author = author
+        self.user = None
+        self.is_skipped = False
+
+    async def interaction_check(self, inter: discord.MessageInteraction) -> bool:
+        self.user = inter.user
+        if inter.user != self.author:
+            await inter.response.send_message(content="Warning : You're not the votable user.", ephemeral=True)
+            return False
+        return True    
+    
+    # When the confirm button is pressed, set the inner value to `True` and
+    # stop the View from listening to more input.
+    # We also send the user an ephemeral message that we're confirming their choice.
+    @discord.ui.button(label='1', style=discord.ButtonStyle.grey)
+    async def one(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_message('You rated 1, thank you!', ephemeral=True)
+        self.value = 1
+        self.stop()
+
+    @discord.ui.button(label='2', style=discord.ButtonStyle.grey)
+    async def two(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_message('You rated 2, thank you!', ephemeral=True)
+        self.value = 2
+        self.stop()
+
+    @discord.ui.button(label='3', style=discord.ButtonStyle.grey)
+    async def three(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_message('You rated 3, thank you!', ephemeral=True)
+        self.value = 3
+        self.stop()
+
+    @discord.ui.button(label='4', style=discord.ButtonStyle.grey)
+    async def four(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_message('You rated 4, thank you!', ephemeral=True)
+        self.value = 4
+        self.stop()
+
+    @discord.ui.button(label='5', style=discord.ButtonStyle.grey)
+    async def five(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_message('You rated 5, thank you!', ephemeral=True)
+        self.value = 5
+        self.stop()
+        
+    @discord.ui.button(label='Skip', style=discord.ButtonStyle.blurple)
+    async def skip(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_message('Vote skipped.', ephemeral=True)
+        self.is_skipped = True
+        self.stop()

--- a/assets/scripts/bot_views.py
+++ b/assets/scripts/bot_views.py
@@ -5,20 +5,19 @@ import typing
 import pretty_midi
 from bot_utils.utils import midi_program_to_emoji
 
-instrument_list = [0, 4, 24]
-
 class InstrumentSelectDropdownView(discord.ui.View):
     def __init__(self, author: typing.Union[discord.Member, discord.User]):
         super().__init__()
         self.value = None
         self.author = author
     
+    # Note: Append instrument program number in `bot_utils.utils`` to extend this select menu. 
     @discord.ui.select(
         placeholder="Select an instrument to render generated midi.",
         options = [discord.SelectOption(
                 label=pretty_midi.program_to_instrument_name(program), 
                 value=program, emoji=midi_program_to_emoji[program],
-                description=f"MIDI Program: {program}") for program in instrument_list]
+                description=f"MIDI Program: {program}") for program in midi_program_to_emoji.keys()]
     )
     async def select_callback(self, interaction, select):
         await interaction.response.send_message(content=f"{select.values[0]} set!",ephemeral=False)

--- a/assets/scripts/bot_views.py
+++ b/assets/scripts/bot_views.py
@@ -3,6 +3,9 @@ sys.path.append("..")
 import discord
 import typing
 import pretty_midi
+from bot_utils.utils import midi_program_to_emoji
+
+instrument_list = [0, 4, 24]
 
 class InstrumentSelectDropdownView(discord.ui.View):
     def __init__(self, author: typing.Union[discord.Member, discord.User]):
@@ -12,11 +15,10 @@ class InstrumentSelectDropdownView(discord.ui.View):
     
     @discord.ui.select(
         placeholder="Select an instrument to render generated midi.",
-        options=[
-            discord.SelectOption(label=pretty_midi.program_to_instrument_name(0), value=0, emoji="🎹",description="MIDI Program: 0"),
-            discord.SelectOption(label=pretty_midi.program_to_instrument_name(4), value=4, emoji="🎹",description="MIDI Program: 4"),
-            discord.SelectOption(label=pretty_midi.program_to_instrument_name(24), value=24, emoji="🎸",description="MIDI Program: 24")
-        ]
+        options = [discord.SelectOption(
+                label=pretty_midi.program_to_instrument_name(program), 
+                value=program, emoji=midi_program_to_emoji[program],
+                description=f"MIDI Program: {program}") for program in instrument_list]
     )
     async def select_callback(self, interaction, select):
         await interaction.response.send_message(content=f"{select.values[0]} set!",ephemeral=False)

--- a/basic_bot.py
+++ b/basic_bot.py
@@ -10,6 +10,8 @@ from generate import generate_song
 
 token = os.environ["BOT_TOKEN"]
 
+discord.utils.setup_logging()
+
 DAY_TIME = "06:00"
 NIGHT_TIME = "18:00"
 
@@ -97,3 +99,4 @@ async def main():
         await bot.start(token)
 
 asyncio.run(main())
+    

--- a/bot_utils/utils.py
+++ b/bot_utils/utils.py
@@ -1,6 +1,12 @@
 import os
 from pydub import AudioSegment
 
+midi_program_to_emoji = {
+    0: '🎹',
+    4: '🎹',
+    24: '🎸',
+}
+
 def getfiles(out_dir):
     os.makedirs(out_dir, exist_ok=True)
     filenames = os.listdir(out_dir)

--- a/bot_utils/utils.py
+++ b/bot_utils/utils.py
@@ -8,14 +8,18 @@ midi_program_to_emoji = {
 }
 
 def getfiles(out_dir):
+    """Get playable audio source and midi in generate folder."""    
     os.makedirs(out_dir, exist_ok=True)
     filenames = os.listdir(out_dir)
-    filenames = [filename.split(".")[0] for filename in filenames if filename.endswith(".mid")]
+    codes = [filename.split(".")[0] for filename in filenames if filename.endswith(".mid")]
     filedict = {}
-    for filename in filenames:
-        mid_path = os.path.join(out_dir, filename+".mid")
-        mp3_path = os.path.join(out_dir, filename+".mp3")
-        filedict[filename] = [mid_path, mp3_path]
+    for c in codes:
+        audios = [filename for filename in filenames if filename.startswith(c) and filename.endswith(".mp3")]
+        for a in audios:
+            filename = a.split(".")[0]
+            mid_path = os.path.join(out_dir, c+".mid")
+            mp3_path = os.path.join(out_dir, a)
+            filedict[filename] = [mid_path, mp3_path]
     return filedict
 
 def get_audio_time(file_path):

--- a/bot_utils/utils.py
+++ b/bot_utils/utils.py
@@ -1,0 +1,20 @@
+import os
+from pydub import AudioSegment
+
+def getfiles(out_dir):
+    os.makedirs(out_dir, exist_ok=True)
+    filenames = os.listdir(out_dir)
+    filenames = [filename.split(".")[0] for filename in filenames if filename.endswith(".mid")]
+    filedict = {}
+    for filename in filenames:
+        mid_path = os.path.join(out_dir, filename+".mid")
+        mp3_path = os.path.join(out_dir, filename+".mp3")
+        filedict[filename] = [mid_path, mp3_path]
+    return filedict
+
+def get_audio_time(file_path):
+    """Get mp3 audio length in %m:%s format."""
+    duration = AudioSegment.from_mp3(file_path).duration_seconds
+    minute = int(duration // 60)
+    second = int(duration % 60)
+    return f"{minute:02d}:{second:02d}"

--- a/bot_utils/utils.py
+++ b/bot_utils/utils.py
@@ -1,11 +1,24 @@
 import os
+import pretty_midi
 from pydub import AudioSegment
 
+# Extend this to add more selection.
 midi_program_to_emoji = {
     0: '🎹',
     4: '🎹',
+    12: '🔔',
+    16: '🎹',
     24: '🎸',
+    56: '🎺',
 }
+
+def get_instrument_emoji(instrument: int):
+    try:
+        emoji = midi_program_to_emoji[int(instrument)]
+    except Exception as e:
+        emoji = pretty_midi.program_to_instrument_name(int(instrument))
+    return emoji
+
 
 def getfiles(out_dir):
     """Get playable audio source and midi in generate folder."""    

--- a/cogs/lofi_transformer_player.py
+++ b/cogs/lofi_transformer_player.py
@@ -20,7 +20,6 @@ class LofiTransformerPlayer(commands.Cog):
         self.bot = bot
         self.load_config()
         self.select_model(self.config["current_model"])
-        self.load_stats()
         self.lastfile = None
 
     def select_model(self, model):
@@ -30,6 +29,8 @@ class LofiTransformerPlayer(commands.Cog):
         self.current_model_ckpt = self.config["model_selection"][self.current_model]["ckpt_path"]
         self.out_dir = self.config["model_selection"][self.current_model]["gen_dir"]
         self.filedict = getfiles(self.out_dir)
+
+        self.load_stats()
     
     def load_stats(self):
         assert (self.config != None) and (self.current_model != None)

--- a/cogs/lofi_transformer_player.py
+++ b/cogs/lofi_transformer_player.py
@@ -132,6 +132,7 @@ class LofiTransformerPlayer(commands.Cog):
         if id is None:
             hint_msg = await ctx.send("Generating...", file=discord.File("img/bocchi.gif"))
             path = generate_song(
+                instrument=self.config["instrument"],
                 ckpt_path=self.current_model_ckpt,
                 out_dir=self.out_dir
             )[0]

--- a/cogs/lofi_transformer_player.py
+++ b/cogs/lofi_transformer_player.py
@@ -8,7 +8,7 @@ import datetime
 import numpy as np
 from discord.ext import commands
 from generate import generate_song, render_midi
-from bot_utils.utils import get_audio_time, getfiles, midi_program_to_emoji
+from bot_utils.utils import get_audio_time, getfiles, get_instrument_emoji
 from assets.scripts.bot_views import Rating, InstrumentSelectDropdownView
 
 CONFIG_PATH = "./config/config.json"
@@ -161,7 +161,7 @@ class LofiTransformerPlayer(commands.Cog):
             complete_id = id+"_"+instrument
             if complete_id not in self.filedict.keys():
                 # Need to render new one.
-                hint_msg = await ctx.send(f"Rendering file to {midi_program_to_emoji[int(instrument)]}...")
+                hint_msg = await ctx.send(f"Rendering file to {get_instrument_emoji(int(instrument))}...")
                 path = render_midi(
                     instrument=int(instrument),
                     out_dir=self.out_dir,
@@ -182,7 +182,7 @@ class LofiTransformerPlayer(commands.Cog):
         await hint_msg.delete()
 
         source = discord.FFmpegPCMAudio(source=mp3_path)
-        embed=discord.Embed(title=f"Now playing... {midi_program_to_emoji[int(instrument)]}", color=0xffc7cd)
+        embed=discord.Embed(title=f"Now playing... {get_instrument_emoji(int(instrument))}", color=0xffc7cd)
         embed.set_thumbnail(url="https://media1.giphy.com/media/mXbQ2IU02cGRhBO2ye/giphy.gif")
         embed.add_field(name="id", value=id, inline=False)
         embed.add_field(name="time", value=get_audio_time(mp3_path), inline=False)

--- a/config/config.json
+++ b/config/config.json
@@ -37,5 +37,6 @@
             "gen_dir": "./gen/sixth_finetune_lofi85_L25"
         }
     },
-    "current_model": "mild-snowball-7"
+    "current_model": "mild-snowball-7",
+    "instrument": 24
 }

--- a/generate.py
+++ b/generate.py
@@ -14,7 +14,7 @@ from utils import write_midi, get_random_string
 
 DATASET_PATH = "./lofi_dataset"
 
-def generate_song(ckpt_path, num_songs=1, out_dir="gen"):
+def generate_song(instrument, ckpt_path, num_songs=1, out_dir="gen"):
     os.makedirs(out_dir, exist_ok=True)
 
     dictionary = pickle.load(open(os.path.join(DATASET_PATH, "dictionary.pkl"), 'rb'))
@@ -66,7 +66,7 @@ def generate_song(ckpt_path, num_songs=1, out_dir="gen"):
         current_bpm = midi_obj.tempo_changes[-1].tempo
 
         # Change the channel instrument.
-        midi_obj.instruments[0].program = 5 # Electrical Piano 1
+        midi_obj.instruments[0].program = instrument
 
         # output midi.
         midi_obj.dump(out_file_path)

--- a/generate.py
+++ b/generate.py
@@ -55,9 +55,9 @@ def generate_song(instrument, ckpt_path, num_songs=1, out_dir="gen"):
                 continue
 
         filename = get_random_string(length=10)
-        out_file_path = os.path.join(out_dir, filename+".mid")
-        wav_file_path = os.path.join(out_dir, filename+".wav")
-        mp3_file_path = os.path.join(out_dir, filename+".mp3")
+        out_file_path = os.path.join(out_dir, filename+f"_{instrument}"+".mid")
+        wav_file_path = os.path.join(out_dir, filename+f"_{instrument}"+".wav")
+        mp3_file_path = os.path.join(out_dir, filename+f"_{instrument}"+".mp3")
         # Get midi object.
         midi_obj = write_midi(res, out_file_path, word2event, dump=False)
 

--- a/generate.py
+++ b/generate.py
@@ -84,6 +84,8 @@ def render_midi(instrument, out_dir, filename, soundfont="./soundfonts/A320U.sf2
     # Change the channel instrument.
     midi_obj.instruments[0].program = instrument
 
+    midi_obj.dump(mid_file_path)
+
     # output wav.
     midi_synth.midi_to_audio(mid_file_path, wav_file_path)
 

--- a/generate.py
+++ b/generate.py
@@ -13,9 +13,8 @@ from models import TransformerModel, network_paras
 from utils import write_midi, get_random_string
 
 DATASET_PATH = "./lofi_dataset"
-CKPT_PATH = "./exp/finetune_lofi/loss_8_params.pt"
 
-def generate_song(ckpt_path=CKPT_PATH, num_songs=1, out_dir="gen"):
+def generate_song(ckpt_path, num_songs=1, out_dir="gen"):
     os.makedirs(out_dir, exist_ok=True)
 
     dictionary = pickle.load(open(os.path.join(DATASET_PATH, "dictionary.pkl"), 'rb'))
@@ -35,9 +34,9 @@ def generate_song(ckpt_path=CKPT_PATH, num_songs=1, out_dir="gen"):
 
     # load weight
     try:
-        net.load_state_dict(torch.load(CKPT_PATH))
+        net.load_state_dict(torch.load(ckpt_path))
     except:
-        state_dict = torch.load(CKPT_PATH)
+        state_dict = torch.load(ckpt_path)
         new_state_dict = OrderedDict()
         for k, v in state_dict.items():
             name = k[7:] 

--- a/generate.py
+++ b/generate.py
@@ -52,7 +52,7 @@ def generate_song(ckpt_path=CKPT_PATH, num_songs=1, out_dir="gen"):
         res = None
         if n_token == 8:
             res, _ = net.inference_from_scratch(dictionary, 0, n_token)
-            while res is None:
+            if res is None:
                 continue
 
         filename = get_random_string(length=10)
@@ -60,7 +60,7 @@ def generate_song(ckpt_path=CKPT_PATH, num_songs=1, out_dir="gen"):
         wav_file_path = os.path.join(out_dir, filename+".wav")
         mp3_file_path = os.path.join(out_dir, filename+".mp3")
         # Get midi object.
-        midi_obj = write_midi(res, out_file_path, word2event)
+        midi_obj = write_midi(res, out_file_path, word2event, dump=False)
 
         # Only take first tempo change.
         midi_obj.tempo_changes = midi_obj.tempo_changes[:2]


### PR DESCRIPTION
## Feature
* In this branch, I developed a command `!instrument` to send a dropdown view, let user select an instrument as default render instrument.
* When generate music, the file name will become `{id}.mid`, `{id}_{instrument}.mp3`.
* In `!play` command, now user can type `!play id instrument` to re-render the generated mid file to audio.
* The song id contains random string id and instrument tag, user can use this new id to play the song like before `!play id`.
* `!play old_id` will give you wrong format error message. 

## Fixed
* `basic_bot.py` now use `run()` command instead of `start()`, to get default error logger configured.
    * [Runtime error not showing when using asyncio to run discord bot](https://stackoverflow.com/questions/74591873/runtime-error-not-showing-when-using-asyncio-to-run-discord-bot)
* Use `setup_hook()` to bind async event loop `update_avatar` and cog loading.