### PR TITLE
Rerender flow refactor

### DIFF
--- a/assets/scripts/bot_views.py
+++ b/assets/scripts/bot_views.py
@@ -24,7 +24,7 @@ class ModelSelectDropdownView(discord.ui.View):
             ) for model in model_list]
         )
         async def select_callback(interaction):
-            await interaction.response.send_message(content=f"{select.values[0]} set!",ephemeral=False)
+            await interaction.response.defer()
             self.value = select.values[0]
             self.stop()
         select.callback = select_callback
@@ -45,6 +45,7 @@ class InstrumentSelectDropdownView(discord.ui.View):
                 description=f"MIDI Program: {program}") for program in midi_program_to_emoji.keys()]
     )
     async def select_callback(self, interaction, select):
+        await interaction.response.defer()
         self.value = select.values[0]
         self.stop()
 
@@ -100,11 +101,13 @@ class Rating(discord.ui.View):
 
     @discord.ui.button(label='Re-render', style=discord.ButtonStyle.green)
     async def rerender(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.value = "placeholder"
         self.is_rerender = True
         self.stop()
         
     @discord.ui.button(label='Skip', style=discord.ButtonStyle.red)
     async def skip(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message('Vote skipped.', ephemeral=True)
+        self.value = "placeholder"
         self.is_skipped = True
         self.stop()

--- a/assets/scripts/bot_views.py
+++ b/assets/scripts/bot_views.py
@@ -45,7 +45,6 @@ class InstrumentSelectDropdownView(discord.ui.View):
                 description=f"MIDI Program: {program}") for program in midi_program_to_emoji.keys()]
     )
     async def select_callback(self, interaction, select):
-        await interaction.response.send_message(content=f"{select.values[0]} set!",ephemeral=False)
         self.value = select.values[0]
         self.stop()
 

--- a/assets/scripts/bot_views.py
+++ b/assets/scripts/bot_views.py
@@ -57,6 +57,7 @@ class Rating(discord.ui.View):
         self.author = author
         self.user = None
         self.is_skipped = False
+        self.is_rerender = False
 
     async def interaction_check(self, inter: discord.MessageInteraction) -> bool:
         self.user = inter.user
@@ -97,8 +98,13 @@ class Rating(discord.ui.View):
         await interaction.response.send_message('You rated 5, thank you!', ephemeral=True)
         self.value = 5
         self.stop()
+
+    @discord.ui.button(label='Re-render', style=discord.ButtonStyle.green)
+    async def rerender(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.is_rerender = True
+        self.stop()
         
-    @discord.ui.button(label='Skip', style=discord.ButtonStyle.blurple)
+    @discord.ui.button(label='Skip', style=discord.ButtonStyle.red)
     async def skip(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message('Vote skipped.', ephemeral=True)
         self.is_skipped = True

--- a/cogs/lofi_transformer_player.py
+++ b/cogs/lofi_transformer_player.py
@@ -71,12 +71,14 @@ class LofiTransformerPlayer(commands.Cog):
         model_emoji_dict = {m: self.config["model_selection"][m]["emoji"] for m in model_list}
 
         view = ModelSelectDropdownView(ctx.author, model_list, model_description_dict, model_emoji_dict)
-        await ctx.send(f"Model Setting.\nCurrent model is {current_model_emoji} **{current_model}**", view=view)
+        model_select_message = await ctx.send(f"Model Setting.\nCurrent model is {current_model_emoji} **{current_model}**", view=view)
 
         await view.wait()
         if view.value == None:
             print("Model select view timeout.")
             return
+        model_emoji = self.config["model_selection"][view.value]["emoji"]
+        await model_select_message.edit(content=f"Model changed to {model_emoji} **{view.value}**", view=None)
         self.select_model(view.value)
 
     @commands.command()
@@ -208,6 +210,7 @@ class LofiTransformerPlayer(commands.Cog):
             if view.value == None:
                 print("Re-render view timeout.")
                 return
+            await vote_area.edit(embed=embed, view=None)
             instrument = int(view.value)
             complete_id = code+"_"+str(instrument)
             if complete_id not in self.filedict.keys():

--- a/cogs/lofi_transformer_player.py
+++ b/cogs/lofi_transformer_player.py
@@ -182,7 +182,7 @@ class LofiTransformerPlayer(commands.Cog):
         vote_embed.set_footer(text="Please rate the song ⏬")
         vote_embed.timestamp = datetime.datetime.now()
         rating_view = Rating(ctx.author)
-        vote_area = await ctx.send(embed=vote_embed, view=rating_view)
+        vote_area = await ctx.send(id, embed=vote_embed, view=rating_view)
         ctx.voice_client.play(source, after=lambda e: print(f'Player error: {e}') if e else None)
         return vote_area, vote_embed, rating_view
     

--- a/cogs/lofi_transformer_player.py
+++ b/cogs/lofi_transformer_player.py
@@ -221,10 +221,8 @@ class LofiTransformerPlayer(commands.Cog):
     @commands.command()
     async def instrument(self, ctx):
         """Show a dropdown selection to set the MIDI render instrument program number."""
-        current_instrument = self.config["instrument"]
-        emoji = get_instrument_emoji(current_instrument)
-
-        view = InstrumentSelectDropdownView(ctx.author)
+        emoji = get_instrument_emoji(self.config["instrument"])
+        view = self.get_instrument_dropdown_view(ctx)
         await ctx.send(f"Instrument Setting.\nCurrent instrument is {emoji} **{pretty_midi.program_to_instrument_name(current_instrument)}**", view=view)
 
         await view.wait()
@@ -246,6 +244,10 @@ class LofiTransformerPlayer(commands.Cog):
     @get.before_invoke
     async def update_dict(self, ctx):
         self.filedict = getfiles(self.out_dir)
+    
+    def get_instrument_dropdown_view(self, ctx):
+        current_instrument = self.config["instrument"]
+        return InstrumentSelectDropdownView(ctx.author)
 
 async def setup(client):
     await client.add_cog(LofiTransformerPlayer(client))

--- a/cogs/lofi_transformer_player.py
+++ b/cogs/lofi_transformer_player.py
@@ -127,7 +127,8 @@ class LofiTransformerPlayer(commands.Cog):
         #TODO: Merge with a get function.
         if id is None:
             instrument = self.config["instrument"]
-            hint_msg = await ctx.send("Generating...", file=discord.File("img/bocchi.gif"))
+            current_model_emoji = self.config["model_selection"][self.current_model]["emoji"]
+            hint_msg = await ctx.send(f"Generating...\nmodel: {current_model_emoji} **{self.current_model}**\ninstrument: {get_instrument_emoji(instrument)} **{pretty_midi.program_to_instrument_name(instrument)}**", file=discord.File("img/bocchi.gif"))
             path = generate_song(
                 instrument=int(instrument),
                 ckpt_path=self.current_model_ckpt,
@@ -176,7 +177,7 @@ class LofiTransformerPlayer(commands.Cog):
         vote_embed.set_thumbnail(url="https://media1.giphy.com/media/mXbQ2IU02cGRhBO2ye/giphy.gif")
         vote_embed.add_field(name="id", value=id, inline=False)
         vote_embed.add_field(name="time", value=get_audio_time(mp3_path), inline=False)
-        vote_embed.add_field(name="instrument", value=pretty_midi.program_to_instrument_name(instrument), inline=False)
+        vote_embed.add_field(name="instrument", value=f"{get_instrument_emoji(instrument)} {pretty_midi.program_to_instrument_name(instrument)}", inline=False)
         vote_embed.add_field(name="model", value=f"{current_model_emoji} {self.current_model}", inline=False)
         vote_embed.set_footer(text="Please rate the song ⏬")
         vote_embed.timestamp = datetime.datetime.now()


### PR DESCRIPTION
## Feature
* Change `!play id instrument` usage to a Re-render dropdown view.
    * User now can choose Re-render in rating view to select the other instrument to render, and than listen to the re-rendered song.

## Fixed
* Make `play_command()` and `play_music()` methods, separate music playing step to these 2 methods.
* Make `get_instrument_dropdown_view()` method to get instrument select dropdown view used in `!instrument` and `!play`.