### PR TITLE
Stop btn dev, Slash command support.

### DIFF
--- a/assets/scripts/bot_views.py
+++ b/assets/scripts/bot_views.py
@@ -99,18 +99,18 @@ class Rating(discord.ui.View):
         await interaction.response.send_message('You rated 5, thank you!', ephemeral=True)
         self.value = 5
         self.stop()
-
-    @discord.ui.button(label='Re-render', style=discord.ButtonStyle.green)
-    async def rerender(self, interaction: discord.Interaction, button: discord.ui.Button):
-        self.value = "placeholder"
-        self.is_rerender = True
-        self.stop()
         
     @discord.ui.button(label='Skip', style=discord.ButtonStyle.blurple)
     async def skip(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message('Vote skipped.', ephemeral=True)
         self.value = "placeholder"
         self.is_skipped = True
+        self.stop()
+
+    @discord.ui.button(label='Re-render', style=discord.ButtonStyle.green)
+    async def rerender(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.value = "placeholder"
+        self.is_rerender = True
         self.stop()
         
     @discord.ui.button(label='Stop', style=discord.ButtonStyle.red)

--- a/assets/scripts/bot_views.py
+++ b/assets/scripts/bot_views.py
@@ -119,28 +119,28 @@ class Rating(discord.ui.View):
         self.value = 5
         self.stop()
         
-    @discord.ui.button(label='Skip', style=discord.ButtonStyle.blurple)
-    async def _skip(self, interaction: discord.Interaction, button: discord.ui.Button):
-        await interaction.response.send_message('Vote skipped.', ephemeral=True)
+    @discord.ui.button(label='Generate', style=discord.ButtonStyle.blurple)
+    async def _regenerate(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.defer()
         self.value = "placeholder"
         self.is_skipped = True
         self.stop()
         
-    @discord.ui.button(label='🔄', style=discord.ButtonStyle.grey)
+    @discord.ui.button(label='Replay', style=discord.ButtonStyle.grey)
     async def _replay(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.defer()
         self.value = "placeholder"
         self.is_replay = True
         self.stop()
 
-    @discord.ui.button(label='🎹', style=discord.ButtonStyle.green)
+    @discord.ui.button(label='Render', style=discord.ButtonStyle.green)
     async def _rerender(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.defer()
         self.value = "placeholder"
         self.is_rerender = True
         self.stop()
         
-    @discord.ui.button(label='🛑', style=discord.ButtonStyle.grey)
+    @discord.ui.button(label='Stop', style=discord.ButtonStyle.grey)
     async def _stop(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.defer()
         self.value = "placeholder"

--- a/assets/scripts/bot_views.py
+++ b/assets/scripts/bot_views.py
@@ -71,50 +71,50 @@ class Rating(discord.ui.View):
     # stop the View from listening to more input.
     # We also send the user an ephemeral message that we're confirming their choice.
     @discord.ui.button(label='1', style=discord.ButtonStyle.grey)
-    async def one(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def _one(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message('You rated 1, thank you!', ephemeral=True)
         self.value = 1
         self.stop()
 
     @discord.ui.button(label='2', style=discord.ButtonStyle.grey)
-    async def two(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def _two(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message('You rated 2, thank you!', ephemeral=True)
         self.value = 2
         self.stop()
 
     @discord.ui.button(label='3', style=discord.ButtonStyle.grey)
-    async def three(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def _three(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message('You rated 3, thank you!', ephemeral=True)
         self.value = 3
         self.stop()
 
     @discord.ui.button(label='4', style=discord.ButtonStyle.grey)
-    async def four(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def _four(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message('You rated 4, thank you!', ephemeral=True)
         self.value = 4
         self.stop()
 
     @discord.ui.button(label='5', style=discord.ButtonStyle.grey)
-    async def five(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def _five(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message('You rated 5, thank you!', ephemeral=True)
         self.value = 5
         self.stop()
         
     @discord.ui.button(label='Skip', style=discord.ButtonStyle.blurple)
-    async def skip(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def _skip(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message('Vote skipped.', ephemeral=True)
         self.value = "placeholder"
         self.is_skipped = True
         self.stop()
 
     @discord.ui.button(label='Re-render', style=discord.ButtonStyle.green)
-    async def rerender(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def _rerender(self, interaction: discord.Interaction, button: discord.ui.Button):
         self.value = "placeholder"
         self.is_rerender = True
         self.stop()
         
     @discord.ui.button(label='Stop', style=discord.ButtonStyle.red)
-    async def stop_music(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def _stop(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.defer()
         self.value = "placeholder"
         self.is_stopped = True

--- a/assets/scripts/bot_views.py
+++ b/assets/scripts/bot_views.py
@@ -59,6 +59,7 @@ class Rating(discord.ui.View):
         self.is_skipped = False
         self.is_rerender = False
         self.is_stopped = False
+        self.is_quitted = False
 
     async def interaction_check(self, inter: discord.MessageInteraction) -> bool:
         self.user = inter.user
@@ -118,4 +119,11 @@ class Rating(discord.ui.View):
         await interaction.response.defer()
         self.value = "placeholder"
         self.is_stopped = True
+        self.stop()
+
+    @discord.ui.button(label='Quit', style=discord.ButtonStyle.grey)
+    async def _quit(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.defer()
+        self.value = "placeholder"
+        self.is_quitted = True
         self.stop()

--- a/assets/scripts/bot_views.py
+++ b/assets/scripts/bot_views.py
@@ -58,6 +58,7 @@ class Rating(discord.ui.View):
         self.user = None
         self.is_skipped = False
         self.is_rerender = False
+        self.is_stopped = False
 
     async def interaction_check(self, inter: discord.MessageInteraction) -> bool:
         self.user = inter.user
@@ -105,9 +106,16 @@ class Rating(discord.ui.View):
         self.is_rerender = True
         self.stop()
         
-    @discord.ui.button(label='Skip', style=discord.ButtonStyle.red)
+    @discord.ui.button(label='Skip', style=discord.ButtonStyle.blurple)
     async def skip(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message('Vote skipped.', ephemeral=True)
         self.value = "placeholder"
         self.is_skipped = True
+        self.stop()
+        
+    @discord.ui.button(label='Stop', style=discord.ButtonStyle.red)
+    async def stop_music(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.defer()
+        self.value = "placeholder"
+        self.is_stopped = True
         self.stop()

--- a/assets/scripts/bot_views.py
+++ b/assets/scripts/bot_views.py
@@ -133,21 +133,21 @@ class Rating(discord.ui.View):
         self.is_replay = True
         self.stop()
 
-    @discord.ui.button(label='Re-render', style=discord.ButtonStyle.green)
+    @discord.ui.button(label='🎹', style=discord.ButtonStyle.green)
     async def _rerender(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.defer()
         self.value = "placeholder"
         self.is_rerender = True
         self.stop()
         
-    @discord.ui.button(label='Stop', style=discord.ButtonStyle.red)
+    @discord.ui.button(label='🛑', style=discord.ButtonStyle.grey)
     async def _stop(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.defer()
         self.value = "placeholder"
         self.is_stopped = True
         self.stop()
 
-    @discord.ui.button(label='Quit', style=discord.ButtonStyle.grey)
+    @discord.ui.button(label='Quit', style=discord.ButtonStyle.red)
     async def _quit(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.defer()
         self.value = "placeholder"

--- a/assets/scripts/bot_views.py
+++ b/assets/scripts/bot_views.py
@@ -60,6 +60,7 @@ class Rating(discord.ui.View):
         self.is_rerender = False
         self.is_stopped = False
         self.is_quitted = False
+        self.is_replay = False
         self.votable = votable
 
     async def interaction_check(self, inter: discord.MessageInteraction) -> bool:
@@ -124,9 +125,17 @@ class Rating(discord.ui.View):
         self.value = "placeholder"
         self.is_skipped = True
         self.stop()
+        
+    @discord.ui.button(label='🔄', style=discord.ButtonStyle.grey)
+    async def _replay(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.defer()
+        self.value = "placeholder"
+        self.is_replay = True
+        self.stop()
 
     @discord.ui.button(label='Re-render', style=discord.ButtonStyle.green)
     async def _rerender(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.defer()
         self.value = "placeholder"
         self.is_rerender = True
         self.stop()

--- a/assets/scripts/bot_views.py
+++ b/assets/scripts/bot_views.py
@@ -51,7 +51,7 @@ class InstrumentSelectDropdownView(discord.ui.View):
 
 # Define a simple View that gives us a confirmation menu
 class Rating(discord.ui.View):
-    def __init__(self, author: typing.Union[discord.Member, discord.User]):
+    def __init__(self, author: typing.Union[discord.Member, discord.User], votable=True):
         super().__init__()
         self.value = None
         self.author = author
@@ -60,6 +60,7 @@ class Rating(discord.ui.View):
         self.is_rerender = False
         self.is_stopped = False
         self.is_quitted = False
+        self.votable = votable
 
     async def interaction_check(self, inter: discord.MessageInteraction) -> bool:
         self.user = inter.user
@@ -73,31 +74,47 @@ class Rating(discord.ui.View):
     # We also send the user an ephemeral message that we're confirming their choice.
     @discord.ui.button(label='1', style=discord.ButtonStyle.grey)
     async def _one(self, interaction: discord.Interaction, button: discord.ui.Button):
-        await interaction.response.send_message('You rated 1, thank you!', ephemeral=True)
+        if self.votable:
+            await interaction.response.send_message('You rated 1, thank you ❗', ephemeral=True)
+        else:
+            await interaction.response.send_message('You already voted ‼️', ephemeral=True)
         self.value = 1
         self.stop()
 
     @discord.ui.button(label='2', style=discord.ButtonStyle.grey)
     async def _two(self, interaction: discord.Interaction, button: discord.ui.Button):
-        await interaction.response.send_message('You rated 2, thank you!', ephemeral=True)
+        if self.votable:
+            await interaction.response.send_message('You rated 2, thank you ❗', ephemeral=True)
+        else:
+            await interaction.response.send_message('You already voted ‼️', ephemeral=True)
         self.value = 2
         self.stop()
 
     @discord.ui.button(label='3', style=discord.ButtonStyle.grey)
     async def _three(self, interaction: discord.Interaction, button: discord.ui.Button):
-        await interaction.response.send_message('You rated 3, thank you!', ephemeral=True)
+        if self.votable:
+            await interaction.response.send_message('You rated 3, thank you ❗', ephemeral=True)
+        else:
+            await interaction.response.send_message('You already voted ‼️', ephemeral=True)
+
         self.value = 3
         self.stop()
 
     @discord.ui.button(label='4', style=discord.ButtonStyle.grey)
     async def _four(self, interaction: discord.Interaction, button: discord.ui.Button):
-        await interaction.response.send_message('You rated 4, thank you!', ephemeral=True)
+        if self.votable:
+            await interaction.response.send_message('You rated 4, thank you ❗', ephemeral=True)
+        else:
+            await interaction.response.send_message('You already voted ‼️', ephemeral=True)
         self.value = 4
         self.stop()
 
     @discord.ui.button(label='5', style=discord.ButtonStyle.grey)
     async def _five(self, interaction: discord.Interaction, button: discord.ui.Button):
-        await interaction.response.send_message('You rated 5, thank you!', ephemeral=True)
+        if self.votable:
+            await interaction.response.send_message('You rated 5, thank you ❗', ephemeral=True)
+        else:
+            await interaction.response.send_message('You already voted ‼️', ephemeral=True)
         self.value = 5
         self.stop()
         

--- a/assets/settings/setting.py
+++ b/assets/settings/setting.py
@@ -6,7 +6,7 @@ LOGGING_CONFIG = {
     "disabled_existing_loggers": False, 
     "formatters":{
         "verbose":{
-            "format": "%(levelname)-10s - %(asctime)s - %(module)-15s : %(message)s"
+            "format": "%(levelname)-6s - %(asctime)s - %(module)-15s : %(message)s"
         },
         "standard":{
             "format": "%(levelname)-6s - %(name)-20s : %(message)s"
@@ -33,12 +33,12 @@ LOGGING_CONFIG = {
     }, 
     "loggers":{
         "bot": {
-            'handlers': ['console'],
+            'handlers': ['console', "file"],
             "level": "INFO", 
             "propagate": False
         }, 
         "lofi_transformer": {
-            'handlers': ['console'],
+            'handlers': ['console', "file"],
             "level": "DEBUG", 
             "propagate": False
         }, 

--- a/assets/settings/setting.py
+++ b/assets/settings/setting.py
@@ -1,0 +1,53 @@
+import logging
+from logging.config import dictConfig
+
+LOGGING_CONFIG = {
+    "version": 1, 
+    "disabled_existing_loggers": False, 
+    "formatters":{
+        "verbose":{
+            "format": "%(levelname)-10s - %(asctime)s - %(module)-15s : %(message)s"
+        },
+        "standard":{
+            "format": "%(levelname)-10s - %(name)-15s : %(message)s"
+        }
+    }, 
+    "handlers":{
+        "console": {
+            'level': "DEBUG", 
+            'class': "logging.StreamHandler",
+            'formatter': "standard"
+        }, 
+        "console2": {
+            'level': "INFO", 
+            'class': "logging.StreamHandler",
+            'formatter': "standard"
+        }, 
+        "file": {
+            'level': "INFO", 
+            'class': "logging.FileHandler",
+            'filename': "logs/infos.log",
+            'mode': "w", 
+            'formatter': "verbose"
+        }, 
+    }, 
+    "loggers":{
+        "bot": {
+            'handlers': ['console'],
+            "level": "INFO", 
+            "propagate": False
+        }, 
+        "lofi_transformer": {
+            'handlers': ['console'],
+            "level": "DEBUG", 
+            "propagate": False
+        }, 
+        "discord": {
+            'handlers': ['console2', "file"],
+            "level": "INFO", 
+            "propagate": False
+        }
+    }
+}
+
+dictConfig(LOGGING_CONFIG)

--- a/assets/settings/setting.py
+++ b/assets/settings/setting.py
@@ -9,7 +9,7 @@ LOGGING_CONFIG = {
             "format": "%(levelname)-10s - %(asctime)s - %(module)-15s : %(message)s"
         },
         "standard":{
-            "format": "%(levelname)-10s - %(name)-15s : %(message)s"
+            "format": "%(levelname)-6s - %(name)-20s : %(message)s"
         }
     }, 
     "handlers":{

--- a/bot.py
+++ b/bot.py
@@ -44,6 +44,9 @@ class Bot(commands.Bot):
         self.update_avatar.start()
         for ext in self.initial_extensions:
             await self.load_extension(ext)
+        logger.info("Syncing command to global...")
+        cmds = await self.tree.sync()
+        logger.info(f"{len(cmds)} commands synced!")
 
     def switch_avatar(self, is_day: True):
         if is_day:

--- a/bot.py
+++ b/bot.py
@@ -1,13 +1,17 @@
 import os
+import logging
 import discord
 from discord.ext import commands, tasks
 from datetime import datetime
 import asyncio
+import assets.settings.setting as setting
 
 token = os.environ["BOT_TOKEN"]
 
 DAY_TIME = "06:00"
 NIGHT_TIME = "18:00"
+
+logger = setting.logging.getLogger("bot")
 
 
 class Bot(commands.Bot):
@@ -34,8 +38,7 @@ class Bot(commands.Bot):
         self.init_avatar()
 
     async def on_ready(self):
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        logger.info(f'Logged in as {self.user} (ID: {self.user.id})')
     
     async def setup_hook(self) -> None:
         self.update_avatar.start()
@@ -46,14 +49,12 @@ class Bot(commands.Bot):
         if is_day:
             with open(self.day_avatar, 'rb') as image:
                 asyncio.get_event_loop().create_task(self.user.edit(avatar=image.read()))
-                # await self.user.edit(avatar=image.read())
-                print("Good morning!")
+                logger.info(f'{self.user} changed its avatar to {self.day_avatar}!')
                 self.day_night_state = "day"
         else:
             with open(self.night_avatar, 'rb') as image:
                 asyncio.get_event_loop().create_task(self.user.edit(avatar=image.read()))
-                # await self.user.edit(avatar=image.read())
-                print("Good evening!")
+                logger.info(f'{self.user} changed its avatar to {self.night_avatar}!')
                 self.day_night_state = "night"
 
     def init_avatar(self):
@@ -70,7 +71,7 @@ class Bot(commands.Bot):
     @tasks.loop(seconds=10)
     async def update_avatar(self):
         if bot.is_closed():
-            print("Bot is closed")
+            logger.warn(f'{self.user} is offline now!')
             return
 
         now = datetime.strftime(datetime.now(), '%H:%M')
@@ -86,8 +87,8 @@ async def on_voice_state_update(member, before, after):
     voice_state = member.guild.voice_client
     if voice_state is not None and len(voice_state.channel.members) == 1:
         # If the bot is connected to a channel and the bot is the only one in the channel
-        print("Bot getting out.")
+        logger.info(f"{bot.user} is getting out from voice channel.")
         await voice_state.disconnect() # Disconnect the bot from the channel
 
 if __name__ == "__main__":
-    bot.run(token)
+    bot.run(token, root_logger=True)

--- a/cogs/lofi_transformer_player.py
+++ b/cogs/lofi_transformer_player.py
@@ -199,6 +199,11 @@ class LofiTransformerPlayer(commands.Cog):
         if rating_view.value == None:
             print("Rating view timeout.")
             return
+        if rating_view.is_stopped:
+            await vote_area.edit(embed=embed, view=None)
+            if ctx.voice_client.is_playing():
+                ctx.voice_client.stop()
+            return
         if rating_view.is_skipped:
             await vote_area.edit(embed=embed, view=None)
             return

--- a/cogs/lofi_transformer_player.py
+++ b/cogs/lofi_transformer_player.py
@@ -208,6 +208,7 @@ class LofiTransformerPlayer(commands.Cog):
         if rating_view.value == None:
             logger.info("Rating view timeout.")
         elif rating_view.is_replay:
+            await self.ensure_voice(ctx)
             await vote_area.edit(embed=embed, view=None)
             await self.play_command(ctx, mp3_path)
         elif rating_view.is_stopped:
@@ -218,9 +219,11 @@ class LofiTransformerPlayer(commands.Cog):
         elif rating_view.is_quitted:
             if ctx.voice_client.is_playing():
                 ctx.voice_client.stop()
+            ctx.voice_client.disconnect()
             await vote_area.edit(embed=embed, view=None)
         elif rating_view.is_skipped:
             await vote_area.edit(embed=embed, view=None)
+            await self.ensure_voice(ctx)
             await self.play(ctx)
         elif rating_view.is_rerender:
             view = self.get_instrument_dropdown_view(ctx)

--- a/cogs/lofi_transformer_player.py
+++ b/cogs/lofi_transformer_player.py
@@ -221,6 +221,7 @@ class LofiTransformerPlayer(commands.Cog):
             await vote_area.edit(embed=embed, view=None)
         elif rating_view.is_skipped:
             await vote_area.edit(embed=embed, view=None)
+            await self.play(ctx)
         elif rating_view.is_rerender:
             view = self.get_instrument_dropdown_view(ctx)
             await vote_area.edit(embed=embed, view=view)

--- a/cogs/lofi_transformer_player.py
+++ b/cogs/lofi_transformer_player.py
@@ -202,6 +202,9 @@ class LofiTransformerPlayer(commands.Cog):
         await rating_view.wait()
         if rating_view.value == None:
             print("Rating view timeout.")
+        elif rating_view.is_replay:
+            await vote_area.edit(embed=embed, view=None)
+            await self.play_command(ctx, mp3_path)
         elif rating_view.is_stopped:
             if ctx.voice_client.is_playing():
                 ctx.voice_client.stop()


### PR DESCRIPTION
## Feature
* Added a Stop button in rating view, it will stop the audio and send rating view again.
* Added a Quit button in rating view, it will stop the audio and delete rating view.
* Vote in rating view now limited only once.
* Setup logger to replace print. Log file saves in `logs` folder.
* Slash command available by using `commands.hybrid_command()`.

## Fixed
* Naming rule in `bot_view.py`.
* Reorder button layout in rating view.

---

Summarized by OpenAI GPT-3

## Features:
- Slash command support
- Setup logger in lofi transformer cog
- Add replay btn in rating view to replay song
- Limit vote only once
- Stop and quit btn in rating view
- Stop btn for stopping playing music

## Fixes:
- Voice check before play func
- Skip->regenerate
- Fixed btn methods to private naming

## Styles:
- Updated button style and name
- Adjust logger setting
- Design the btn layout in rating view
- Reorder the btn layout in rating view